### PR TITLE
deployment: default to proper published img

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO ?= go
 OCI_BIN ?= docker
 
-IMAGE_REGISTRY ?= quay.io/maiqueb
+IMAGE_REGISTRY ?= quay.io/mduarted
 IMAGE_NAME ?= multus-dynamic-networks-controller
 IMAGE_TAG ?= latest
 

--- a/manifests/dynamic-networks-controller.yaml
+++ b/manifests/dynamic-networks-controller.yaml
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: dynamic-networks-controller
       containers:
         - name: dynamic-networks-controller
-          image: quay.io/maiqueb/multus-dynamic-networks-controller:latest
+          image: quay.io/mduarted/multus-dynamic-networks-controller:latest
           command: [ "/dynamic-networks-controller" ]
           args:
             - "-config=/etc/dynamic-networks-controller/dynamic-networks-config.json"


### PR DESCRIPTION
This PR points to a manually released image.

Eventually, the right thing to do is use CI best practices to automatically release these images.
