### PR TITLE
Fix each ds instance listens to events on its node

### DIFF
--- a/cmd/dynamic-networks-controller/networks-controller.go
+++ b/cmd/dynamic-networks-controller/networks-controller.go
@@ -110,9 +110,9 @@ func listenOnCoLocatedNode() v1coreinformerfactory.SharedInformerOption {
 		func(options *v1.ListOptions) {
 			const (
 				filterKey           = "spec.nodeName"
-				hostnameEnvVariable = "HOSTNAME"
+				nodeNameEnvVariable = "NODE_NAME"
 			)
-			options.FieldSelector = fields.OneTermEqualSelector(filterKey, os.Getenv(hostnameEnvVariable)).String()
+			options.FieldSelector = fields.OneTermEqualSelector(filterKey, os.Getenv(nodeNameEnvVariable)).String()
 		})
 }
 

--- a/manifests/dynamic-networks-controller.yaml
+++ b/manifests/dynamic-networks-controller.yaml
@@ -95,6 +95,11 @@ spec:
       serviceAccountName: dynamic-networks-controller
       containers:
         - name: dynamic-networks-controller
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                    fieldPath: spec.nodeName
           image: quay.io/mduarted/multus-dynamic-networks-controller:latest
           command: [ "/dynamic-networks-controller" ]
           args:

--- a/templates/dynamic-networks-controller.yaml.j2
+++ b/templates/dynamic-networks-controller.yaml.j2
@@ -95,6 +95,11 @@ spec:
       serviceAccountName: dynamic-networks-controller
       containers:
         - name: dynamic-networks-controller
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                    fieldPath: spec.nodeName
           image: {{ IMAGE_REGISTRY }}/multus-dynamic-networks-controller:latest
           command: [ "/dynamic-networks-controller" ]
           args:


### PR DESCRIPTION
Depends-on: #16 

This PR ensures the hostname of the controller pods is the name of the nodes where they are scheduled.

This enables the controller to listen exclusively to events on the node where it is deployed, and thus request delegates from multus for pods scheduled on the node it manages.
