### PR TITLE
Add kind e2e

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,4 +1,4 @@
-name: Go
+name: Unit tests
 
 on:
   push:

--- a/.github/workflows/e2e-container.yaml
+++ b/.github/workflows/e2e-container.yaml
@@ -1,0 +1,37 @@
+name: e2e tests - containerd
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - run: |
+          pip3 install --user --upgrade j2cli
+          j2 --version
+
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Setup kind cluster
+        run: hack/e2e-kind-cluster-setup.sh
+
+      - name: Test - provisioning the examples
+        run: e2e/test-provisioning-examples.sh
+
+      - name: Cleanup cluster
+        run: |
+          kind delete cluster           # gracefully remove the cluster
+          docker rm -f $(docker ps -qa) # remove the registry + any leftover

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+multus-cni/

--- a/e2e/test-provisioning-examples.sh
+++ b/e2e/test-provisioning-examples.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xe
+
+kubectl apply -f examples/original-setup.yaml
+kubectl wait --for=condition=ready --timeout=60s pod macvlan1-worker1
+
+kubectl apply -f examples/interface-add.yaml
+kubectl apply -f examples/interface-remove.yaml
+kubectl delete -f examples/original-setup.yaml
+

--- a/hack/e2e-kind-cluster-setup.sh
+++ b/hack/e2e-kind-cluster-setup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -xe
+
+CNI_VERSION=${CNI_VERSION:-0.4.0}
+OCI_BIN=${OCI_BIN:-docker}
+IMG_REGISTRY=${IMAGE_REGISTRY:-localhost:5000/maiqueb}
+
+setup_cluster() {
+    git clone https://github.com/k8snetworkplumbingwg/multus-cni/
+    pushd multus-cni/e2e
+    trap "popd" RETURN SIGINT
+    ./get_tools.sh
+    CNI_VERSION="$CNI_VERSION" ./generate_yamls.sh
+    OCI_BIN="$OCI_BIN" ./setup_cluster.sh
+}
+
+push_local_image() {
+    OCI_BIN="$OCI_BIN" IMAGE_REGISTRY="$IMG_REGISTRY" make manifests
+    OCI_BIN="$OCI_BIN" IMAGE_REGISTRY="$IMG_REGISTRY" make img-build
+    "$OCI_BIN" push "$IMG_REGISTRY/multus-dynamic-networks-controller:latest"
+}
+
+cleanup() {
+    rm -rf multus-cni
+    git checkout -- manifests/
+}
+
+trap "cleanup" EXIT
+setup_cluster
+push_local_image
+kubectl apply -f manifests/dynamic-networks-controller.yaml
+kubectl wait -nkube-system --for=condition=ready --timeout=180s -l app=dynamic-networks-controller pods


### PR DESCRIPTION
This PR adds a kind based cluster to check the e2e functionality of the repo.

It simply runs the e2e scripts of the multus project, which for now, is more than enough for us.

Follow-up PRs will add a golang based e2e test suite to check the functionality of the project.

Depends-on: #20 

Fixes: #7 