### PR TITLE
ci, img push: push images when main branch is updated

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -2,7 +2,7 @@ name: Push container image
 on: 
   push:
     branches:
-      - master
+      - main
 env:
   image-push-owner: 'maiqueb'
 jobs:


### PR DESCRIPTION
Previously we were attempting to push images on changes to the `master` branch ... which didn't exist in this project.
