### PR TITLE
deploy: use github container registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 GO ?= go
 OCI_BIN ?= docker
 
-IMAGE_REGISTRY ?= quay.io/mduarted
+IMAGE_REGISTRY ?= ghcr.io/maiqueb
 IMAGE_NAME ?= multus-dynamic-networks-controller
-IMAGE_TAG ?= latest
+IMAGE_TAG ?= latest-amd64
 
 CRI_SOCKET_PATH ?= "/host/run/containerd/containerd.sock"
 
@@ -21,7 +21,7 @@ img-build: build test
 	$(OCI_BIN) build -t ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} -f images/Dockerfile .
 
 manifests:
-	IMAGE_REGISTRY=${IMAGE_REGISTRY} CRI_SOCKET_PATH=${CRI_SOCKET_PATH} hack/generate_manifests.sh
+	IMAGE_REGISTRY=${IMAGE_REGISTRY} IMAGE_TAG=${IMAGE_TAG} CRI_SOCKET_PATH=${CRI_SOCKET_PATH} hack/generate_manifests.sh
 
 test:
 	$(GO) test -v ./...

--- a/hack/e2e-kind-cluster-setup.sh
+++ b/hack/e2e-kind-cluster-setup.sh
@@ -4,6 +4,7 @@ set -xe
 CNI_VERSION=${CNI_VERSION:-0.4.0}
 OCI_BIN=${OCI_BIN:-docker}
 IMG_REGISTRY=${IMAGE_REGISTRY:-localhost:5000/maiqueb}
+IMG_TAG="latest"
 
 setup_cluster() {
     git clone https://github.com/k8snetworkplumbingwg/multus-cni/
@@ -15,9 +16,9 @@ setup_cluster() {
 }
 
 push_local_image() {
-    OCI_BIN="$OCI_BIN" IMAGE_REGISTRY="$IMG_REGISTRY" make manifests
-    OCI_BIN="$OCI_BIN" IMAGE_REGISTRY="$IMG_REGISTRY" make img-build
-    "$OCI_BIN" push "$IMG_REGISTRY/multus-dynamic-networks-controller:latest"
+    OCI_BIN="$OCI_BIN" IMAGE_REGISTRY="$IMG_REGISTRY" IMAGE_TAG="$IMG_TAG" make manifests
+    OCI_BIN="$OCI_BIN" IMAGE_REGISTRY="$IMG_REGISTRY" IMAGE_TAG="$IMG_TAG" make img-build
+    "$OCI_BIN" push "$IMG_REGISTRY/multus-dynamic-networks-controller:$IMG_TAG"
 }
 
 cleanup() {

--- a/hack/generate_manifests.sh
+++ b/hack/generate_manifests.sh
@@ -7,7 +7,8 @@ templates_dir="$ROOT/templates"
 
 for file in `ls $templates_dir/`; do
 	echo $file
-	j2 -e IMAGE_REGISTRY -e CRI_SOCKET_PATH ${templates_dir}/$file -o manifests/${file%.j2}
+	j2 -e IMAGE_REGISTRY -e IMAGE_TAG -e CRI_SOCKET_PATH ${templates_dir}/$file -o manifests/${file%.j2}
 done
 unset IMAGE_REGISTRY
+unset IMAGE_TAG
 unset CRI_SOCKET_PATH

--- a/manifests/dynamic-networks-controller.yaml
+++ b/manifests/dynamic-networks-controller.yaml
@@ -100,7 +100,7 @@ spec:
               valueFrom:
                 fieldRef:
                     fieldPath: spec.nodeName
-          image: quay.io/mduarted/multus-dynamic-networks-controller:latest
+          image: ghcr.io/maiqueb/multus-dynamic-networks-controller:latest-amd64
           command: [ "/dynamic-networks-controller" ]
           args:
             - "-config=/etc/dynamic-networks-controller/dynamic-networks-config.json"

--- a/templates/dynamic-networks-controller.yaml.j2
+++ b/templates/dynamic-networks-controller.yaml.j2
@@ -100,7 +100,7 @@ spec:
               valueFrom:
                 fieldRef:
                     fieldPath: spec.nodeName
-          image: {{ IMAGE_REGISTRY }}/multus-dynamic-networks-controller:latest
+          image: {{ IMAGE_REGISTRY }}/multus-dynamic-networks-controller:{{ IMAGE_TAG }}
           command: [ "/dynamic-networks-controller" ]
           args:
             - "-config=/etc/dynamic-networks-controller/dynamic-networks-config.json"


### PR DESCRIPTION
Now that we automatically build & push the latest version of the controller to github's registry, we can update the project's manifests to feature said registry.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>