### PR TITLE
Allow templating of namespace in manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ OCI_BIN ?= docker
 IMAGE_REGISTRY ?= ghcr.io/maiqueb
 IMAGE_NAME ?= multus-dynamic-networks-controller
 IMAGE_TAG ?= latest-amd64
+NAMESPACE ?= kube-system
 
 CRI_SOCKET_PATH ?= "/host/run/containerd/containerd.sock"
 
@@ -21,7 +22,7 @@ img-build: build test
 	$(OCI_BIN) build -t ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} -f images/Dockerfile .
 
 manifests:
-	IMAGE_REGISTRY=${IMAGE_REGISTRY} IMAGE_TAG=${IMAGE_TAG} CRI_SOCKET_PATH=${CRI_SOCKET_PATH} hack/generate_manifests.sh
+	IMAGE_REGISTRY=${IMAGE_REGISTRY} IMAGE_TAG=${IMAGE_TAG} CRI_SOCKET_PATH=${CRI_SOCKET_PATH} NAMESPACE=${NAMESPACE} hack/generate_manifests.sh
 
 test:
 	$(GO) test -v ./pkg/...

--- a/hack/generate_manifests.sh
+++ b/hack/generate_manifests.sh
@@ -7,8 +7,9 @@ templates_dir="$ROOT/templates"
 
 for file in `ls $templates_dir/`; do
 	echo $file
-	j2 -e IMAGE_REGISTRY -e IMAGE_TAG -e CRI_SOCKET_PATH ${templates_dir}/$file -o manifests/${file%.j2}
+	j2 -e IMAGE_REGISTRY -e IMAGE_TAG -e CRI_SOCKET_PATH -e NAMESPACE ${templates_dir}/$file -o manifests/${file%.j2}
 done
 unset IMAGE_REGISTRY
 unset IMAGE_TAG
 unset CRI_SOCKET_PATH
+unset NAMESPACE

--- a/templates/dynamic-networks-controller.yaml.j2
+++ b/templates/dynamic-networks-controller.yaml.j2
@@ -42,19 +42,19 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: dynamic-networks-controller
-    namespace: kube-system
+    namespace: {{ NAMESPACE }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dynamic-networks-controller
-  namespace: kube-system
+  namespace: {{ NAMESPACE }}
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: dynamic-networks-controller-config
-  namespace: kube-system
+  namespace: {{ NAMESPACE }}
   labels:
     tier: node
     app: multus-dynamic-networks-controller
@@ -69,7 +69,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: dynamic-networks-controller-ds
-  namespace: kube-system
+  namespace: {{ NAMESPACE }}
   labels:
     tier: node
     app: dynamic-networks-controller


### PR DESCRIPTION
**What this PR does / why we need it**:

As an administrator, I don't want to instal external components under Kubernetes' kube-system.

This patch allows me to easily parametrize the target namespace.
