### PR TITLE
e2e: use namespace param when hotplugging

### DIFF
--- a/e2e/client/types.go
+++ b/e2e/client/types.go
@@ -110,7 +110,7 @@ func (c *E2EClient) DeletePod(pod *corev1.Pod) error {
 }
 
 func (c *E2EClient) AddNetworkToPod(pod *corev1.Pod, networkName string, namespace string, ifaceToAdd string) error {
-	pod.ObjectMeta.Annotations[nettypes.NetworkAttachmentAnnot] = dynamicNetworksAnnotation(pod, networkName, "ns1", ifaceToAdd, nil)
+	pod.ObjectMeta.Annotations[nettypes.NetworkAttachmentAnnot] = dynamicNetworksAnnotation(pod, networkName, namespace, ifaceToAdd, nil)
 	_, err := c.k8sClient.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
 	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We were mistakenly using an hard-coded value. Luckily, it was the correct one - but this would explode the moment someone added an e2e test that attempted to hot plug a network to a pod on a namespace other than `ns1`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

