### PR TITLE
Send desired IP / MAC address to multus server

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -96,7 +96,11 @@ var _ = Describe("Multus dynamic networks controller", func() {
 			It("manages to add a new interface to a running pod", func() {
 				const ifaceToAdd = "ens58"
 
-				Expect(clients.AddNetworkToPod(pod, networkName, namespace, ifaceToAdd)).To(Succeed())
+				Expect(clients.AddNetworkToPod(pod, &nettypes.NetworkSelectionElement{
+					Name:             networkName,
+					Namespace:        namespace,
+					InterfaceRequest: ifaceToAdd,
+				})).To(Succeed())
 				Eventually(filterPodNonDefaultNetworks).Should(
 					WithTransform(
 						status.CleanMACAddressesFromStatus(),

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -138,10 +138,10 @@ func clusterConfig() (*rest.Config, error) {
 }
 
 func macvlanNetworkWithoutIPAM(networkName string, namespaceName string) *nettypes.NetworkAttachmentDefinition {
-	macvlanConfig := `{
+	macvlanConfig := fmt.Sprintf(`{
         "cniVersion": "0.3.0",
         "disableCheck": true,
-        "name": "tenant-network",
+        "name": "%s",
         "plugins": [
             {
                 "type": "macvlan",
@@ -149,7 +149,7 @@ func macvlanNetworkWithoutIPAM(networkName string, namespaceName string) *nettyp
                 "mode": "bridge"
             }
         ]
-    }`
+    }`, networkName)
 	return generateNetAttachDefSpec(networkName, namespaceName, macvlanConfig)
 }
 
@@ -207,4 +207,8 @@ func PodNetworkSelectionElements(networkConfig ...dynamicNetworkInfo) map[string
 
 func namespacedName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
+}
+
+func ipWithMask(ip string, netmaskLen int) string {
+	return fmt.Sprintf("%s/%d", ip, netmaskLen)
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 		BeforeEach(func() {
 			_, err := clients.AddNamespace(namespace)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = clients.AddNetAttachDef(macvlanNetworkWithWhereaboutsIPAMNetwork(networkName, namespace))
+			_, err = clients.AddNetAttachDef(macvlanNetworkWithoutIPAM(networkName, namespace))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -133,7 +133,7 @@ func clusterConfig() (*rest.Config, error) {
 	return config, nil
 }
 
-func macvlanNetworkWithWhereaboutsIPAMNetwork(networkName string, namespaceName string) *nettypes.NetworkAttachmentDefinition {
+func macvlanNetworkWithoutIPAM(networkName string, namespaceName string) *nettypes.NetworkAttachmentDefinition {
 	macvlanConfig := `{
         "cniVersion": "0.3.0",
         "disableCheck": true,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds tests asserting runtime configuration (pod / MAC addresses) can be requested for the delegate being added.

It also adds an e2e test proving that removing an interface with runtime configuration is possible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #42 

**Special notes for your reviewer** *(optional)*:
