### PR TITLE
Correct the provided examples

### DIFF
--- a/examples/interface-add.yaml
+++ b/examples/interface-add.yaml
@@ -11,7 +11,14 @@ metadata:
             },
             {
                 "name": "macvlan1-config",
-                "interface": "ens4"
+                "interface": "ens4",
+                "ips": ["10.1.1.66/24"]
+            },
+            {
+                "name": "macvlan1-config",
+                "interface": "ens41",
+                "mac": "02:03:04:05:06:07",
+                "ips": ["10.1.1.111/24"]
             }
     ]'
   labels:

--- a/examples/interface-remove.yaml
+++ b/examples/interface-remove.yaml
@@ -4,7 +4,12 @@ kind: Pod
 metadata:
   name: macvlan1-worker1
   annotations:
-    k8s.v1.cni.cncf.io/networks: '[]'
+    k8s.v1.cni.cncf.io/networks: '[
+        {
+            "name": "macvlan1-config",
+            "ips": [ "10.1.1.11/24" ]
+        }
+    ]'
   labels:
     app: macvlan
 spec:

--- a/examples/original-setup.yaml
+++ b/examples/original-setup.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   config: '{
             "cniVersion": "0.4.0",
+            "name": "macvlan1-config",
             "plugins": [
                 {
                     "type": "macvlan",


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently cannot hotplug an interface if it doesn't feature the `name` attribute in the plugin configuration.

This happens because we compute the delegate CNI configuration directly from that JSON config.

Furthermore, the examples are updated to provide the following:
- hotplug w/ IP configuration
- hotplug w/ MAC address configuration
- hotunplug (cannot hot-unplug if the interface name is not shown in the `NetworkSelectionElement`)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:
Depends-on: #39 

