### PR TITLE
build, multus: go get multus-cni w/ runtime config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,4 +117,4 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.4
 )
 
-replace gopkg.in/k8snetworkplumbingwg/multus-cni.v3 => github.com/k8snetworkplumbingwg/multus-cni v0.0.0-20220926142625-1aac2431b86a
+replace gopkg.in/k8snetworkplumbingwg/multus-cni.v3 => github.com/k8snetworkplumbingwg/multus-cni v0.0.0-20221014153412-fa8a6e688081

--- a/go.sum
+++ b/go.sum
@@ -570,8 +570,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k8snetworkplumbingwg/multus-cni v0.0.0-20220926142625-1aac2431b86a h1:VybuVhaxPDMFhuIEovqyIo6v0yqPRNZTJezbt3Zz7/I=
-github.com/k8snetworkplumbingwg/multus-cni v0.0.0-20220926142625-1aac2431b86a/go.mod h1:UuztUt9fVZCed9aexDAf//44CFiVQwrUnI8o4W4N8L8=
+github.com/k8snetworkplumbingwg/multus-cni v0.0.0-20221014153412-fa8a6e688081 h1:lonGN339dXcAMpSuluEvSN1GdCFgSFY5rNTlzKW8pUQ=
+github.com/k8snetworkplumbingwg/multus-cni v0.0.0-20221014153412-fa8a6e688081/go.mod h1:6Gc0CK1oJNOqUY3bGC6tppdnsNzwj0BZhNLrvEN1BWc=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0 h1:MjRRgZyTGo90G+UrwlDQjU+uG4Z7By65qvQxGoILT/8=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0/go.mod h1:nqCI7aelBJU61wiBeeZWJ6oi4bJy5nrjkM6lWIMA4j0=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -265,6 +265,7 @@ func (pnc *PodNetworksController) addNetworks(dynamicAttachmentRequest *DynamicA
 				pod.GetName(),
 				string(pod.UID),
 				[]byte(netAttachDef.Spec.Config),
+				interfaceAttributes(*netToAdd),
 			))
 
 		if err != nil {
@@ -308,6 +309,7 @@ func (pnc *PodNetworksController) removeNetworks(dynamicAttachmentRequest *Dynam
 				pod.GetName(),
 				string(pod.UID),
 				[]byte(netAttachDef.Spec.Config),
+				interfaceAttributes(*netToRemove),
 			))
 		if err != nil {
 			return fmt.Errorf("failed to remove delegate: %v", err)
@@ -450,4 +452,14 @@ func removeIfaceEventFormat(pod *corev1.Pod, network *nadv1.NetworkSelectionElem
 		network.InterfaceRequest,
 		network.Name,
 	)
+}
+
+func interfaceAttributes(networkData nadv1.NetworkSelectionElement) *multusapi.DelegateInterfaceAttributes {
+	if len(networkData.IPRequest) > 0 || networkData.MacRequest != "" {
+		return &multusapi.DelegateInterfaceAttributes{
+			IPRequest:  networkData.IPRequest,
+			MacRequest: networkData.MacRequest,
+		}
+	}
+	return nil
 }

--- a/vendor/gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/server/api/api.go
+++ b/vendor/gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/server/api/api.go
@@ -73,7 +73,7 @@ func GetAPIEndpoint(endpoint string) string {
 }
 
 // CreateDelegateRequest creates Request for delegate API request
-func CreateDelegateRequest(cniCommand, cniContainerID, cniNetNS, cniIFName, podNamespace, podName, podUID string, cniConfig []byte) *Request {
+func CreateDelegateRequest(cniCommand, cniContainerID, cniNetNS, cniIFName, podNamespace, podName, podUID string, cniConfig []byte, interfaceAttributes *DelegateInterfaceAttributes) *Request {
 	return &Request{
 		Env: map[string]string{
 			"CNI_COMMAND":     strings.ToUpper(cniCommand),
@@ -82,6 +82,7 @@ func CreateDelegateRequest(cniCommand, cniContainerID, cniNetNS, cniIFName, podN
 			"CNI_IFNAME":      cniIFName,
 			"CNI_ARGS":        fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s;K8S_POD_UID=%s", podNamespace, podName, podUID),
 		},
-		Config: cniConfig,
+		Config:              cniConfig,
+		InterfaceAttributes: interfaceAttributes,
 	}
 }

--- a/vendor/gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/server/api/types.go
+++ b/vendor/gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/server/api/types.go
@@ -24,6 +24,20 @@ type Request struct {
 	Env map[string]string `json:"env,omitempty"`
 	// CNI configuration passed via stdin to the CNI plugin
 	Config []byte `json:"config,omitempty"`
+	// Annotation for Delegate request
+	InterfaceAttributes *DelegateInterfaceAttributes `json:"interfaceAttributes,omitempty"`
+}
+
+// DelegateInterfaceAttributes annotates delegate request for additional config
+type DelegateInterfaceAttributes struct {
+	// IPRequest contains an optional requested IP address for this network
+	// attachment
+	IPRequest []string `json:"ips,omitempty"`
+	// MacRequest contains an optional requested MAC address for this
+	// network attachment
+	MacRequest string `json:"mac,omitempty"`
+	// CNIArgs contains additional CNI arguments for the network interface
+	CNIArgs *map[string]interface{} `json:"cni-args"`
 }
 
 // Response represents the response (computed in the CNI server) for

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -488,7 +488,7 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/inf.v0 v0.9.1
 ## explicit
 gopkg.in/inf.v0
-# gopkg.in/k8snetworkplumbingwg/multus-cni.v3 v3.9.1 => github.com/k8snetworkplumbingwg/multus-cni v0.0.0-20220926142625-1aac2431b86a
+# gopkg.in/k8snetworkplumbingwg/multus-cni.v3 v3.9.1 => github.com/k8snetworkplumbingwg/multus-cni v0.0.0-20221014153412-fa8a6e688081
 ## explicit; go 1.17
 gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/logging
 gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/server/api
@@ -938,4 +938,4 @@ sigs.k8s.io/yaml
 # k8s.io/mount-utils => k8s.io/mount-utils v0.24.4
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.24.4
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.4
-# gopkg.in/k8snetworkplumbingwg/multus-cni.v3 => github.com/k8snetworkplumbingwg/multus-cni v0.0.0-20220926142625-1aac2431b86a
+# gopkg.in/k8snetworkplumbingwg/multus-cni.v3 => github.com/k8snetworkplumbingwg/multus-cni v0.0.0-20221014153412-fa8a6e688081


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the multus dependency to a version that allows specifying the runtime config.

With this, it is now possible for a particular pod to specify particular interface attributes, like MAC / IP addresses.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

