### PR TITLE
Handle old pods without network selection elements

### DIFF
--- a/e2e/client/types.go
+++ b/e2e/client/types.go
@@ -230,12 +230,7 @@ func podMeta(podName string, namespace string, label map[string]string, annotati
 }
 
 func dynamicNetworksAnnotation(pod *corev1.Pod, newIfaceConfigs ...*nettypes.NetworkSelectionElement) string {
-	currentNetworkSelectionElementsString, wasFound := pod.ObjectMeta.Annotations[nettypes.NetworkAttachmentAnnot]
-	if !wasFound {
-		return ""
-	}
-
-	currentNetworkSelectionElements, err := annotations.ParsePodNetworkAnnotations(currentNetworkSelectionElementsString, pod.GetNamespace())
+	currentNetworkSelectionElements, err := extractPodNetworkSelectionElements(pod)
 	if err != nil {
 		return ""
 	}
@@ -282,4 +277,17 @@ func removeFromDynamicNetworksAnnotation(pod *corev1.Pod, networkName string, ne
 		newSelectionElements = "[]"
 	}
 	return newSelectionElements
+}
+
+func extractPodNetworkSelectionElements(pod *corev1.Pod) ([]*nettypes.NetworkSelectionElement, error) {
+	var currentNetworkSelectionElements []*nettypes.NetworkSelectionElement
+	currentNetworkSelectionElementsString, wasFound := pod.ObjectMeta.Annotations[nettypes.NetworkAttachmentAnnot]
+	if wasFound {
+		var err error
+		currentNetworkSelectionElements, err = annotations.ParsePodNetworkAnnotations(currentNetworkSelectionElementsString, pod.GetNamespace())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return currentNetworkSelectionElements, nil
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 			})
 		})
 
-		XContext("a provisioned pod featuring *only* the cluster's default network", func() {
+		Context("a provisioned pod featuring *only* the cluster's default network", func() {
 			var pod *corev1.Pod
 
 			BeforeEach(func() {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -346,8 +346,8 @@ func (pnc *PodNetworksController) updatePodNetworkStatus(pod *corev1.Pod, newIfa
 
 func networkSelectionElements(podAnnotations map[string]string, podNamespace string) ([]*nadv1.NetworkSelectionElement, error) {
 	podNetworks, ok := podAnnotations[nadv1.NetworkAttachmentAnnot]
-	if !ok {
-		return nil, fmt.Errorf("the pod is missing the \"%s\" annotation on its annotations: %+v", nadv1.NetworkAttachmentAnnot, podAnnotations)
+	if !ok || podNetworks == "" {
+		return []*nadv1.NetworkSelectionElement{}, nil
 	}
 	podNetworkSelectionElements, err := annotations.ParsePodNetworkAnnotations(podNetworks, podNamespace)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows hot-plugging interfaces into a pod without any `network-selection-elements`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #43

**Special notes for your reviewer** *(optional)*:

