### PR TITLE
controller: allow hot[plug|unplug] for nets without spec.config.name

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,5 @@ Below you can find information on how to push local code changes to a kind clust
 - deploy the controller: `kubectl apply -f manifests/dynamic-networks-controller.yaml`
 
 ## Known limitations
-- the networks being hot-plugged **must** feature the `name` attribute in the `spec.config`. This is tracked in this [issue](https://github.com/maiqueb/multus-dynamic-networks-controller/issues/45).
 - the pod controller is not [level driven](https://stackoverflow.com/questions/1966863/level-vs-edge-trigger-network-event-mechanisms). This is tracked in this [RFE](https://github.com/maiqueb/multus-dynamic-networks-controller/issues/48).
 - plug / unplug interfaces to networks requiring device-plugin interaction. We must investigate this further; an RFE **may** be opened once we have the required data.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -230,10 +230,9 @@ func clusterConfig() (*rest.Config, error) {
 }
 
 func macvlanNetworkWithoutIPAM(networkName string, namespaceName string) *nettypes.NetworkAttachmentDefinition {
-	macvlanConfig := fmt.Sprintf(`{
+	macvlanConfig := `{
         "cniVersion": "0.3.0",
         "disableCheck": true,
-        "name": "%s",
         "plugins": [
             {
                 "type": "macvlan",
@@ -241,7 +240,7 @@ func macvlanNetworkWithoutIPAM(networkName string, namespaceName string) *nettyp
                 "mode": "bridge"
             }
         ]
-    }`, networkName)
+    }`
 	return generateNetAttachDefSpec(networkName, namespaceName, macvlanConfig)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the pod network's controller to add / remove network interfaces to networks that do **not** feature the `name` attribute in `spec.config`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #45 

**Special notes for your reviewer** *(optional)*:

