### PR TITLE
ci: add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - maiqueb


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR configures dependabot to stalk the repo checking for module updates.
