### PR TITLE
ci, release: was missing with clause

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -52,7 +52,8 @@ jobs:
       - name: Release the kraken
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
-        generate_release_notes: true
-        files: |
-          manifests/crio-dynamic-networks-controller.yaml
-          manifests/dynamic-networks-controller.yaml
+        with:
+          generate_release_notes: true
+          files: |
+            manifests/crio-dynamic-networks-controller.yaml
+            manifests/dynamic-networks-controller.yaml


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

**What this PR does / why we need it**:
The correct syntax for the `gh-release` github action is:
```yaml
      - name: Release
        uses: softprops/action-gh-release@v1
        if: startsWith(github.ref, 'refs/tags/')
        with:
          files: Release.txt
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

