### PR TITLE
ci, release: templating the manifest requires j2

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -45,6 +45,12 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:${{  github.ref_name }}
           file: images/Dockerfile
 
+      - name: Install the j2 dependency
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          pip3 install --user --upgrade j2cli
+          j2 --version
+
       - name: Template release manifests
         if: startsWith(github.ref, 'refs/tags/')
         run: IMAGE_TAG=${{  github.ref_name }} make manifests


### PR DESCRIPTION
**What this PR does / why we need it**:
We cannot template the manifests without the `j2` depedency. This PR install it for the `image-push` action.
