### PR TITLE
Revert "ci, release: add dummy tag to test this works"

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -5,7 +5,6 @@ on:
       - main
     tags:
       - 'v*.*.*'
-      - 'gogotagmachine'
 env:
   image-push-owner: 'maiqueb'
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Now that we know the release machine does what it is supposed to do, we can stop reacting to this dummy tag.

This reverts commit 3eebfc0d46720a41a68836ba350494b6e86d22fc.
