### PR TITLE
Fix e2e tests for cnao deployment

### DIFF
--- a/.github/workflows/e2e-containerd.yaml
+++ b/.github/workflows/e2e-containerd.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Run e2e tests
         env:
           KUBECONFIG: /home/runner/.kube/config
+          LOWER_DEVICE: eth1
         run: make e2e/test
 
       - name: Cleanup cluster

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -246,7 +246,7 @@ func macvlanNetworkWithoutIPAM(networkName string, namespaceName string) *nettyp
 
 func macvlanNetworkWitStaticIPAM(networkName string, namespaceName string) *nettypes.NetworkAttachmentDefinition {
 	macvlanConfig := fmt.Sprintf(`{
-        "cniVersion": "1.0.0",
+        "cniVersion": "0.3.0",
         "disableCheck": true,
         "name": "%s",
         "plugins": [

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -26,10 +26,9 @@ func TestDynamicNetworksControllerE2E(t *testing.T) {
 
 var _ = Describe("Multus dynamic networks controller", func() {
 	const (
-		defaultLowerDeviceIfaceName = "eth0"
-		namespace                   = "ns1"
-		networkName                 = "tenant-network"
-		podName                     = "tiny-winy-pod"
+		namespace   = "ns1"
+		networkName = "tenant-network"
+		podName     = "tiny-winy-pod"
 	)
 	var clients *client.E2EClient
 
@@ -47,7 +46,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 		BeforeEach(func() {
 			_, err := clients.AddNamespace(namespace)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = clients.AddNetAttachDef(macvlanNetworkWithoutIPAM(networkName, namespace, defaultLowerDeviceIfaceName))
+			_, err = clients.AddNetAttachDef(macvlanNetworkWithoutIPAM(networkName, namespace, lowerDeviceName()))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -131,7 +130,7 @@ var _ = Describe("Multus dynamic networks controller", func() {
 				macAddress := "02:03:04:05:06:07"
 
 				BeforeEach(func() {
-					_, err := clients.AddNetAttachDef(macvlanNetworkWitStaticIPAM(ipamNetworkToAdd, namespace, defaultLowerDeviceIfaceName))
+					_, err := clients.AddNetAttachDef(macvlanNetworkWitStaticIPAM(ipamNetworkToAdd, namespace, lowerDeviceName()))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(clients.AddNetworkToPod(pod, &nettypes.NetworkSelectionElement{
 						Name:             ipamNetworkToAdd,
@@ -328,4 +327,16 @@ func namespacedName(namespace, name string) string {
 
 func ipWithMask(ip string, netmaskLen int) string {
 	return fmt.Sprintf("%s/%d", ip, netmaskLen)
+}
+
+func lowerDeviceName() string {
+	const (
+		defaultLowerDeviceIfaceName = "eth0"
+		lowerDeviceEnvVarKeyName    = "LOWER_DEVICE"
+	)
+
+	if lowerDeviceIfaceName, wasFound := os.LookupEnv(lowerDeviceEnvVarKeyName); wasFound {
+		return lowerDeviceIfaceName
+	}
+	return defaultLowerDeviceIfaceName
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables [CNAO](https://github.com/kubevirt/cluster-network-addons-operator) e2e test framework to successfully run the `multus-dynamic-networks-controller` e2e tests.

That is a requirement for the CNAO operator to ship a project.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:
Once CNAO's test framework bumps their containernetworking plugins version, we can resume using plugins of version 1.0.0 on the tests.

